### PR TITLE
Clarify service config examples

### DIFF
--- a/WinSetup/Config.yaml
+++ b/WinSetup/Config.yaml
@@ -22,19 +22,21 @@ apps:
     - ffmpeg
     - vlc
 services:
+  # Use the service Name from Get-Service for each entry
+  # Lists under each role can contain multiple service names
   workstation:
     disable:
       - DiagTrack
       - OneSyncSvc
       - XblAuthManager
-      - ...
+      # Add more services here, e.g. RemoteRegistry
     enable:
       - WSearch
   server:
     disable:
       - PrintSpooler
       - Fax
-      - ...
+      # Add more services here, e.g. AppMgmt
 firewall:
   trusted_subnet: auto
   block_telemetry: true

--- a/WinSetup/Readme.md
+++ b/WinSetup/Readme.md
@@ -16,6 +16,20 @@
    `WinSetup.ps1`, `WinSetup.py`, `config.yaml`, `modules/`, `.gitignore`, etc.
 3. Run `WinSetup.ps1` as Administrator
 4. Review logs and Markdown summary after completion
+## Configuring Services
+Add service names under `services.<role>.disable` or `services.<role>.enable` in `config.yaml`. Use the short **Name** from `Get-Service` and list one entry per line:
+
+```yaml
+services:
+  workstation:
+    disable:
+      - DiagTrack
+      - OneSyncSvc
+      # - RemoteRegistry  # example additional service
+    enable:
+      - WSearch
+```
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- document service config syntax in WinSetup Readme
- clarify placeholders in config.yaml with comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b3d059e4832e842176750ac51ce3