### PR TITLE
Run WinUpdate before Scoop

### DIFF
--- a/WinSetup/Readme.md
+++ b/WinSetup/Readme.md
@@ -8,6 +8,7 @@
 - Detailed logging, Markdown summaries, and Event Log integration
 - Parallel Scoop installs and optional-app prompts
 - Python handoff for cross-platform or advanced automation
+- Automated Windows Update with reboot handling
 
 ## Usage
 

--- a/WinSetup/WinSetup.ps1
+++ b/WinSetup/WinSetup.ps1
@@ -48,11 +48,11 @@ $role = $config.role
 Import-Module (Join-Path $ScriptRoot "modules\Preflight.psm1")
 Import-Module (Join-Path $ScriptRoot "modules\Services.psm1")
 Import-Module (Join-Path $ScriptRoot "modules\Firewall.psm1")
+Import-Module (Join-Path $ScriptRoot "modules\WinUpdate.psm1")
 Import-Module (Join-Path $ScriptRoot "modules\Scoop.psm1")
 Import-Module (Join-Path $ScriptRoot "modules\GitRepo.psm1")
 Import-Module (Join-Path $ScriptRoot "modules\PythonHandoff.psm1")
 Import-Module (Join-Path $ScriptRoot "modules\Reporting.psm1")
-Import-Module (Join-Path $ScriptRoot "modules\WinUpdate.psm1")
 
 # --- Global Logging Setup ---
 $Global:LogFile = "$env:USERPROFILE\Desktop\WinSetup_log.txt"
@@ -80,6 +80,7 @@ try {
     Preflight::Run -Config $config -Role $role
     Services::Run -Config $config -Role $role
     Firewall::Run -Config $config
+    WinUpdate\Run
     Scoop::Run -Config $config
     GitRepo::Run -Config $config
     PythonHandoff::Run -Config $config


### PR DESCRIPTION
## Summary
- convert `WinUpdate.psm1` to expose a `Run` function
- call Windows Update before installing Scoop apps
- document automated Windows Update in README

## Testing
- `pwsh --version`
- `pwsh -NoProfile -Command "Get-Command ./WinSetup/WinSetup.ps1"`
- `pwsh -NoProfile -Command "Import-Module ./WinSetup/Modules/WinUpdate.psm1; (Get-Command -Name Run).Name"`


------
https://chatgpt.com/codex/tasks/task_e_6856baaa5e64832eb38ed8ef4f235b2b